### PR TITLE
feat: case insensitive query strings

### DIFF
--- a/src/__test__/alb.test.ts
+++ b/src/__test__/alb.test.ts
@@ -38,6 +38,16 @@ o.spec('AlbGateway', () => {
     o(req.query.getAll('api')).deepEquals(['abc123']);
   });
 
+  o('should be case-insensitive query parameters', () => {
+    const newReq = clone(AlbExample);
+    delete newReq.queryStringParameters!['foo'];
+    newReq.queryStringParameters!['FoO'] = 'bar';
+
+    const req = new LambdaAlbRequest(newReq, fakeContext, fakeLog);
+    o(req.query.get('foo')).deepEquals('bar');
+    o(req.query.getAll('foo')).deepEquals(['bar']);
+  });
+
   // ALB events don't seem to handle multiple query parameters
   //   o('should extract all query parameters', () => {
   //     const newReq = clone(ApiGatewayExample);

--- a/src/__test__/api.gateway.test.ts
+++ b/src/__test__/api.gateway.test.ts
@@ -37,6 +37,16 @@ o.spec('ApiGateway', () => {
     o(req.query.getAll('foo')).deepEquals(['bar']);
   });
 
+  o('should be case-insensitive query parameters', () => {
+    const obj = clone(ApiGatewayExample);
+    delete obj.multiValueQueryStringParameters!['foo'];
+    obj.multiValueQueryStringParameters!['FoO'] = ['bar'];
+
+    const req = new LambdaApiGatewayRequest(ApiGatewayExample, fakeContext, fakeLog);
+    o(req.query.get('foo')).deepEquals('bar');
+    o(req.query.getAll('foo')).deepEquals(['bar']);
+  });
+
   o('should extract all query parameters', () => {
     const newReq = clone(ApiGatewayExample);
     newReq.multiValueQueryStringParameters!.foo = ['foo', 'bar'];

--- a/src/__test__/cloudfront.test.ts
+++ b/src/__test__/cloudfront.test.ts
@@ -38,6 +38,14 @@ o.spec('CloudFront', () => {
     o(req.query.getAll('foo')).deepEquals(['bar']);
   });
 
+  o('should be case-insensitive query parameters', () => {
+    const newReq = clone(CloudfrontExample);
+    newReq.Records[0].cf.request.querystring = `?FoO=bar`;
+    const req = new LambdaCloudFrontRequest(newReq, fakeContext, fakeLog);
+    o(req.query.get('foo')).deepEquals('bar');
+    o(req.query.getAll('foo')).deepEquals(['bar']);
+  });
+
   o('should extract all query parameters', () => {
     const newReq = clone(CloudfrontExample);
     newReq.Records[0].cf.request.querystring = `?foo=foo&foo=bar`;

--- a/src/request.alb.ts
+++ b/src/request.alb.ts
@@ -36,7 +36,13 @@ export class LambdaAlbRequest extends LambdaHttpRequest<ALBEvent, ALBResult> {
   }
 
   loadQueryString(): URLSearchParams {
-    return new URLSearchParams(this.event.queryStringParameters);
+    const ret = new URLSearchParams();
+    if (this.event.queryStringParameters == null) return ret;
+
+    for (const [key, value] of Object.entries(this.event.queryStringParameters)) {
+      ret.append(key.toLowerCase(), value ?? 'true');
+    }
+    return ret;
   }
 
   get method(): string {

--- a/src/request.api.gateway.ts
+++ b/src/request.api.gateway.ts
@@ -39,7 +39,7 @@ export class LambdaApiGatewayRequest extends LambdaHttpRequest<APIGatewayEvent, 
     if (this.event.multiValueQueryStringParameters == null) return query;
     for (const [key, values] of Object.entries(this.event.multiValueQueryStringParameters)) {
       if (values == null) continue;
-      for (const value of values) query.append(key, value);
+      for (const value of values) query.append(key.toLowerCase(), value);
     }
     return query;
   }

--- a/src/request.cloudfront.ts
+++ b/src/request.cloudfront.ts
@@ -47,8 +47,8 @@ export class LambdaCloudFrontRequest extends LambdaHttpRequest<CloudFrontRequest
 
   loadQueryString(): URLSearchParams {
     const query = this.event.Records[0].cf.request.querystring;
-    if (query == null || query[0] == null) return new URLSearchParams();
-    return new URLSearchParams(query[0] === '?' ? query.substr(1) : query);
+    if (query == null) return new URLSearchParams();
+    return new URLSearchParams(query.toLowerCase());
   }
 
   get path(): string {

--- a/src/request.http.ts
+++ b/src/request.http.ts
@@ -79,7 +79,11 @@ export abstract class LambdaHttpRequest<
   abstract isBase64Encoded: boolean;
 
   _query: URLSearchParams;
-  /** Query string parameters */
+  /**
+   * Query string parameters
+   *
+   * All query parameters have been normalized into lowercase
+   */
   get query(): URLSearchParams {
     if (this._query == null) this._query = this.loadQueryString();
     return this._query;


### PR DESCRIPTION
While it is valid to use `?aPi=foo&API=bar` this has caused issues with old tools which adjust or uppercase all the query parameters