### PR TITLE
build: Reset github token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
@@ -14,11 +16,13 @@ jobs:
         id: release
         with:
           release-type: node
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
 
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - uses: linz/action-typescript@v3


### PR DESCRIPTION
#### Motivation 
`release-please` has been blocked by security team, and to enable it we will need to setup PAT for them via `linz-li-bot` account.  

#### Modification

- We have setup the `linz-li-bot` secrets in https://github.com/linz/github-tf/blob/2034c5aa1364473446cff6be2d81d3250fa6dac4/src/repo/repo.linz.js.ts#L26
- Update the code changes to point to the new secrets